### PR TITLE
feat: Changes in management of layer dependencies and metapackage names

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -166,4 +166,4 @@ matrix:
     - centos6
     - centos7
 
-branches: [ master, integration, ci_*, pci_*, release_* ]
+branches: [ master, integration, experimental*, ci_*, pci_*, release_* ]

--- a/.layerapi2_dependencies
+++ b/.layerapi2_dependencies
@@ -1,0 +1,4 @@
+root@mfcom
+python3@mfcom
+monitoring@mfext
+#+python3_circus@mfext

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,14 @@ MODULE_LOWERCASE=mfsysmon
 -include $(MFEXT_HOME)/share/main_root.mk
 
 all:: directories
-	echo "root@mfcom" >$(MFSYSMON_HOME)/.layerapi2_dependencies
 	cd adm && $(MAKE)
 	cd config && $(MAKE)
+	cd layers && $(MAKE)
 
 clean::
 	cd config && $(MAKE) clean
 	cd adm && $(MAKE) clean
+	cd layers && $(MAKE) clean
 
 directories:
 	@for DIR in config bin; do mkdir -p $(MFSYSMON_HOME)/$$DIR; done

--- a/layers/Makefile
+++ b/layers/Makefile
@@ -1,0 +1,13 @@
+include ../adm/root.mk
+include $(MFEXT_HOME)/share/subdir_root.mk
+
+SUBDIRS=$(shell ls -d layer*)
+
+all::
+	@for SUBDIR in $(SUBDIRS); do OLDPWD=`pwd`; cd $$SUBDIR || exit 1; $(MAKE) all || exit 1; cd $${OLDPWD}; done
+
+clean::
+	@for SUBDIR in $(SUBDIRS); do OLDPWD=`pwd`; cd $$SUBDIR || exit 1; $(MAKE) clean || exit 1; cd $${OLDPWD}; done
+
+doc:
+	@for SUBDIR in $(SUBDIRS); do OLDPWD=`pwd`; cd $$SUBDIR || exit 1; $(MAKE) doc || exit 1; cd $${OLDPWD}; done

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -1,0 +1,2 @@
+root@mfsysmon
+default@mfcom

--- a/layers/layer9_default/.layerapi2_label
+++ b/layers/layer9_default/.layerapi2_label
@@ -1,0 +1,1 @@
+default@mfsysmon

--- a/layers/layer9_default/Makefile
+++ b/layers/layer9_default/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk


### PR DESCRIPTION
(only minimal and full)
Associated with changes in mfext _metwork.spec, this reduces the number of layers installed by default when installing mfsysmon (only necessary mfext layers are installed)
Metapackage metwork-mfsysmon-minimal only installs the necessary layers for mfsysmon to work properly
Metapackage metwork-mfsysmon or metwork-mfbase-full installs all mfsysmon layers

linked to #26 (mfsysmon part)