### PR TITLE
feat: replace MODULE* environment variables names by MFMODULE* (MODUL…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MODULE=MFSYSMON
-MODULE_LOWERCASE=mfsysmon
+MFMODULE=MFSYSMON
+MFMODULE_LOWERCASE=mfsysmon
 
 -include adm/root.mk
 -include $(MFEXT_HOME)/share/main_root.mk

--- a/adm/telegraf_collector_custom_diskio.py
+++ b/adm/telegraf_collector_custom_diskio.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from telegraf_unixsocket_client import TelegrafUnixSocketClient
 from mflog import getLogger
 
-MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
-SOCKET_PATH = os.path.join(MODULE_RUNTIME_HOME, "var", "telegraf.socket")
+MFMODULE_RUNTIME_HOME = os.environ["MFMODULE_RUNTIME_HOME"]
+SOCKET_PATH = os.path.join(MFMODULE_RUNTIME_HOME, "var", "telegraf.socket")
 LOGGER = getLogger("telegraf_collector_custom_diskio")
 
 

--- a/adm/telegraf_collector_custom_netio.py
+++ b/adm/telegraf_collector_custom_netio.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from telegraf_unixsocket_client import TelegrafUnixSocketClient
 from mflog import getLogger
 
-MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
-SOCKET_PATH = os.path.join(MODULE_RUNTIME_HOME, "var", "telegraf.socket")
+MFMODULE_RUNTIME_HOME = os.environ["MFMODULE_RUNTIME_HOME"]
+SOCKET_PATH = os.path.join(MFMODULE_RUNTIME_HOME, "var", "telegraf.socket")
 LOGGER = getLogger("telegraf_collector_custom_netio")
 
 

--- a/adm/telegraf_collector_custom_netstat.py
+++ b/adm/telegraf_collector_custom_netstat.py
@@ -11,8 +11,8 @@ from telegraf_unixsocket_client import TelegrafUnixSocketClient
 from mflog import getLogger
 from mfutil import BashWrapper
 
-MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
-SOCKET_PATH = os.path.join(MODULE_RUNTIME_HOME, "var", "telegraf.socket")
+MFMODULE_RUNTIME_HOME = os.environ["MFMODULE_RUNTIME_HOME"]
+SOCKET_PATH = os.path.join(MFMODULE_RUNTIME_HOME, "var", "telegraf.socket")
 LOGGER = getLogger("telegraf_collector_custom_netstat")
 CMD = "ss -t -a -n"
 STATES = {

--- a/config/Makefile
+++ b/config/Makefile
@@ -4,4 +4,4 @@ include ../adm/root.mk
 include $(MFEXT_HOME)/share/subdir_root.mk
 include $(MFCOM_HOME)/share/config_subdir.mk
 
-all:: $(MODULE_HOME)/config/telegraf.conf $(MODULE_HOME)/config/circus.ini
+all:: $(MFMODULE_HOME)/config/telegraf.conf $(MFMODULE_HOME)/config/circus.ini

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -7,39 +7,39 @@ cmd={{MFSYSMON_HOME}}/bin/telegraf_collector_custom_diskio.py
 args=
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_diskio.stdout
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_diskio.stdout
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_diskio.stderr
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_diskio.stderr
 copy_env = True
 autostart = True
 respawn = True
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 
 [watcher:telegraf_collector_custom_netstat]
 cmd={{MFSYSMON_HOME}}/bin/telegraf_collector_custom_netstat.py
 args=
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netstat.stdout
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netstat.stdout
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netstat.stderr
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netstat.stderr
 copy_env = True
 autostart = True
 respawn = True
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 
 [watcher:telegraf_collector_custom_netio]
 cmd={{MFSYSMON_HOME}}/bin/telegraf_collector_custom_netio.py
 args=
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netio.stdout
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netio.stdout
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netio.stderr
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_custom_netio.stderr
 copy_env = True
 autostart = True
 respawn = True
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 
 {% endraw %}
 {% endblock %}

--- a/config/config.ini
+++ b/config/config.ini
@@ -28,7 +28,7 @@ minimal_level[DEV]=DEBUG
 # duplicate some log messages in JSON to a specific file (for external monitoring tool)
 # If json_file value is:
 # null => the feature is desactivated
-# AUTO => the json_file is @@@MODULE_RUNTIME_HOME@@@/log/json_logs.log if
+# AUTO => the json_file is @@@MFMODULE_RUNTIME_HOME@@@/log/json_logs.log if
 #         [admin]/hostname != null else null (desactivated)
 json_file=AUTO
 
@@ -91,5 +91,5 @@ external_service_address=null
 [circus]
 
 # You probably don't want to change anything in this section
-endpoint=ipc://{{MODULE_RUNTIME_HOME}}/var/circus.socket
-pubsub_endpoint=ipc://{{MODULE_RUNTIME_HOME}}/var/circus_pubsub.socket
+endpoint=ipc://{{MFMODULE_RUNTIME_HOME}}/var/circus.socket
+pubsub_endpoint=ipc://{{MFMODULE_RUNTIME_HOME}}/var/circus_pubsub.socket

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ def get_version():
     """
     :return: # The short X.Y version.
     """
-    return ".".join(os.environ.get('MODULE_VERSION',
+    return ".".join(os.environ.get('MFMODULE_VERSION',
                                    'unknown.unknown').split('.')[0:-1])
 
 
@@ -17,7 +17,7 @@ def get_release():
     """
     :return: the full version, including alpha/beta/rc tags
     """
-    return os.environ.get('MODULE_VERSION', 'unknown')
+    return os.environ.get('MFMODULE_VERSION', 'unknown')
 
 
 def build_intersphinx_mapping_url(current_module, module):


### PR DESCRIPTION
…E_HOME becomes MFMODULE_HOME and so on)

BREAKING CHANGE: old variables names are no longer defined, they should not be used anymore (be careful with existing plugins)